### PR TITLE
feat: handle login failures

### DIFF
--- a/promo_app/lib/screens/login_screen.dart
+++ b/promo_app/lib/screens/login_screen.dart
@@ -8,13 +8,29 @@ class LoginScreen extends StatelessWidget {
 
   Future<void> _signInGoogle() async {
     final googleSignIn = GoogleSignIn();
-    await googleSignIn.signIn();
-    onLogin();
+    try {
+      final account = await googleSignIn.signIn();
+      if (account != null) {
+        onLogin();
+      } else {
+        debugPrint('Google sign-in canceled or failed');
+      }
+    } catch (e) {
+      debugPrint('Google sign-in error: $e');
+    }
   }
 
   Future<void> _signInFacebook() async {
-    await FacebookAuth.instance.login();
-    onLogin();
+    try {
+      final result = await FacebookAuth.instance.login();
+      if (result.status == LoginStatus.success) {
+        onLogin();
+      } else {
+        debugPrint('Facebook sign-in failed: ${result.message}');
+      }
+    } catch (e) {
+      debugPrint('Facebook sign-in error: $e');
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- add error handling for Google and Facebook sign-in

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6877ae27db0c8326a77b8fe580a041be